### PR TITLE
FIX: psの結果が出力されないことがある

### DIFF
--- a/05-memory-management/cow.c
+++ b/05-memory-management/cow.c
@@ -18,7 +18,7 @@ static void child_fn(char *p) {
 	printf("*** child ps info before memory access ***:\n");
 	fflush(stdout);
 	snprintf(command, COMMAND_SIZE,
-		 "ps -o pid,comm,vsz,rss,min_flt,maj_flt | grep ^%d",
+		 "ps -o pid,comm,vsz,rss,min_flt,maj_flt | grep '^ *%d'",
 		 getpid());	
 	system(command);
 	printf("*** free memory info before memory access ***:\n");


### PR DESCRIPTION
pidが5桁未満の場合、行が空白で始まるためgrepの条件に適合しません。